### PR TITLE
Reflected upstream changes to libzfs

### DIFF
--- a/modules/fs/zfs/src/memlist.c
+++ b/modules/fs/zfs/src/memlist.c
@@ -40,7 +40,7 @@ add_to_devlist(devlist_t * d, const char * device, const char * state, const cha
 
     strcpy(d->device, device);
     strcpy(d->state, state);
-    strncpy(d->pool, pool, ZPOOL_MAXNAMELEN);
+    strncpy(d->pool, pool, MAXNAMELEN);
     d->message = message;
 
     return 0;

--- a/modules/fs/zfs/src/memlist.h
+++ b/modules/fs/zfs/src/memlist.h
@@ -19,7 +19,7 @@ struct devlist {
     char * device;
     char * state;
     const char * message;
-    char pool[ZPOOL_MAXNAMELEN];
+    char pool[MAXNAMELEN];
 
     devlist_t * next;
 };


### PR DESCRIPTION
- `ZPOOL/ZFS_MAXNAMELEN` renamed to `MAXNAMELEN` to reflect upstream changes
- new ZPOOL states as defined in `zfs_msgid_table` (see [upstream](https://github.com/openzfs/zfs/blob/5365b0747a51edeef9c24213929eafb0444ccb78/lib/libzfs/libzfs_status.c))
- removed zpool_get_status ifdef block as newer libzfs should require `&errata` argument everywhere
- default option for case in vdev_status was changed so that it does not assert for `ZPOOL_STATUS_OK` and instead prints unknown state. `ZPOOL_STATUS_OK` is now as one of the cases 