### PR TITLE
fix: build fs/zfs on FreeBSD prior to 13

### DIFF
--- a/modules/fs/zfs/src/Makefile
+++ b/modules/fs/zfs/src/Makefile
@@ -40,6 +40,10 @@ LDADD= 		-lzfs -lnvpair
 
 endif 
 
+ifeq  ($(and $(shell test $(UNAME_S) == "FreeBSD"; echo $$?),$(shell test `uname -K` -lt 1300000; echo $$?)),0)
+CFLAGS+=	-DFREEBSD_NO_OPENZFS
+endif
+
 all: zio.c $(OBJ)
 	$(CC) $(CFLAGS) $(DPADD) -o $(PROG) $(OBJ) $(LDADD)
 

--- a/modules/fs/zfs/src/vdev_status.c
+++ b/modules/fs/zfs/src/vdev_status.c
@@ -23,8 +23,12 @@ zpool_print_vdev(zpool_handle_t * zhp, void * data) {
     nvlist_t * config, * nvroot;
     vdev_stat_t * vs;
 
+#if defined(FREEBSD_NO_OPENZFS)
+    reason = zpool_get_status(zhp, &msgId);
+#else
     zpool_errata_t errata;
     reason = zpool_get_status(zhp, &msgId, &errata);
+#endif
 
     config = zpool_get_config(zhp, NULL);
 
@@ -234,6 +238,7 @@ zpool_print_vdev(zpool_handle_t * zhp, void * data) {
                         "\tThen import it to correct the mismatch.\n");
                 break;
 
+#if !defined(FREEBSD_NO_OPENZFS)
             case ZPOOL_STATUS_ERRATA:
                 (void) snprintf(zstat->err_message, ERR_MESSAGE_SIZE, "status: The ZFS pool contains an on-disk "
                         "format incompatibility.\n"
@@ -241,6 +246,7 @@ zpool_print_vdev(zpool_handle_t * zhp, void * data) {
                         "This will return the pool to a state in which it may be imported by other implementations.\n"
                         "action: Scrub the affected pool with 'zpool scrub'.\n");
                 break;
+#endif
 
             case ZPOOL_STATUS_OK:
                 (void) snprintf(zstat->err_message, ERR_MESSAGE_SIZE, "status: OK\n");


### PR DESCRIPTION
d6dab2c broke fs/zfs on FreeBSD versions prior to 13. Some of the
ZFS-related symbols included in that commit are not in FreeBSD's ZFS
implementation (but were found in OpenZFS). FreeBSD did not adopt
OpenZFS until FreeBSD 13.

This commit enables building of fs/zfs on FreeBSD both with and without
OpenZFS.

Fixes #3 